### PR TITLE
explicitly specify maven exec-plugin

### DIFF
--- a/chapter06/java/commented/pom.xml
+++ b/chapter06/java/commented/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter06/java/completed/pom.xml
+++ b/chapter06/java/completed/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter06/java/skeleton/pom.xml
+++ b/chapter06/java/skeleton/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter08/java/commented/pom.xml
+++ b/chapter08/java/commented/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter08/java/completed/pom.xml
+++ b/chapter08/java/completed/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter08/java/skeleton/pom.xml
+++ b/chapter08/java/skeleton/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter09/java/commented/pom.xml
+++ b/chapter09/java/commented/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter09/java/completed/pom.xml
+++ b/chapter09/java/completed/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/chapter09/java/skeleton/pom.xml
+++ b/chapter09/java/skeleton/pom.xml
@@ -18,6 +18,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
some version of Maven doesn't allow to call `exec:java` if exec-plugin isn't declared in
the `pom.xml`. This PR fixes this problem...